### PR TITLE
Refactor Torn scheduling into watchers

### DIFF
--- a/bot/commands/torn/stock.py
+++ b/bot/commands/torn/stock.py
@@ -1,8 +1,9 @@
 from bot.classes.command import command
 from enums.bot_data import BotData
+from modules.torn_tasks import send_stock_report
 
 
 @command
 async def stock(update, context):
     torn = context.bot_data[BotData.TORN]
-    await torn.stock()
+    await send_stock_report(torn)

--- a/bot/commands/torn/train.py
+++ b/bot/commands/torn/train.py
@@ -4,8 +4,9 @@ from telegram.ext import ContextTypes
 from bot.classes.command import command
 from enums.bot_data import BotData
 from modules.torn import Torn
+from modules.torn_tasks import send_train_status
 
 @command
 async def train(update : Update, context: ContextTypes.DEFAULT_TYPE):
     torn : Torn = context.bot_data[BotData.TORN]
-    await torn.trains()
+    await send_train_status(torn)

--- a/bot/watchers/torn_bounty.py
+++ b/bot/watchers/torn_bounty.py
@@ -1,0 +1,44 @@
+import logging
+from typing import Any, Dict, List, Tuple
+
+from telegram.ext import ContextTypes
+
+from bot.classes.watcher import Watcher
+from enums.bot_data import BotData
+from modules.torn import Torn
+from modules.torn_tasks import get_valid_bounties, watch_player_bounty
+
+
+class TornBountyWatcher(Watcher):
+    interval = 30 * 60
+
+    @classmethod
+    async def job(cls, context: ContextTypes.DEFAULT_TYPE) -> None:
+        torn = context.application.bot_data.get(BotData.TORN)
+        if torn is None:
+            logging.warning("Torn instance not available for bounty watcher")
+            return
+
+        monitor = await get_valid_bounties(torn, 1_000_000)
+        if not monitor:
+            torn.discovered_bounties = []
+            return
+
+        update_discovered: List[Tuple[int, int]] = []
+        new_bounties: List[Dict[str, Any]] = []
+
+        for bounty in monitor:
+            record = (bounty.get("player_id"), bounty.get("valid_until"))
+            if record not in torn.discovered_bounties:
+                new_bounties.append(bounty)
+            update_discovered.append(record)
+
+        torn.discovered_bounties = update_discovered
+
+        for bounty in new_bounties:
+            logging.info(
+                "New bounty found: %s with $%s, scheduling watcher",
+                bounty.get('name'),
+                bounty.get('reward')
+            )
+            context.application.create_task(watch_player_bounty(torn, bounty))

--- a/bot/watchers/torn_company.py
+++ b/bot/watchers/torn_company.py
@@ -1,0 +1,82 @@
+import logging
+from datetime import datetime, time, timedelta
+from typing import Optional
+
+import pytz
+from telegram.ext import ContextTypes
+
+from bot.classes.watcher import Watcher
+from enums.bot_data import BotData
+from modules.torn import Torn
+from modules.torn_tasks import send_stock_report, send_train_status
+
+
+def _seconds_until(target: time, tz) -> float:
+    now = datetime.now(tz)
+    target_datetime = now.replace(
+        hour=target.hour,
+        minute=target.minute,
+        second=target.second,
+        microsecond=0
+    )
+    if target_datetime <= now:
+        target_datetime += timedelta(days=1)
+    return (target_datetime - now).total_seconds()
+
+
+class _DailyTornWatcher(Watcher):
+    timezone = pytz.timezone("CET")
+    interval = 24 * 60 * 60
+    target_time = time(0, 0)
+
+    @classmethod
+    def setup(cls, app):
+        if app.job_queue is None:
+            raise ValueError("Application instance does not have a job queue.")
+
+        first = _seconds_until(cls.target_time, cls.timezone)
+        app.job_queue.run_repeating(cls.job, interval=cls.interval, first=first)
+
+    @classmethod
+    def _get_torn(cls, context: ContextTypes.DEFAULT_TYPE) -> Optional[Torn]:
+        torn = context.application.bot_data.get(BotData.TORN)
+        if torn is None:
+            logging.warning("Torn instance not available for watcher %s", cls.__name__)
+        return torn
+
+
+class TornCompanyUpdateWatcher(_DailyTornWatcher):
+    target_time = time(6, 50)
+
+    @classmethod
+    async def job(cls, context: ContextTypes.DEFAULT_TYPE) -> None:
+        torn = cls._get_torn(context)
+        if torn is None:
+            return
+
+        await torn.update_company()
+        logging.info("Company data updated by watcher")
+
+
+class TornStockWatcher(_DailyTornWatcher):
+    target_time = time(7, 0)
+
+    @classmethod
+    async def job(cls, context: ContextTypes.DEFAULT_TYPE) -> None:
+        torn = cls._get_torn(context)
+        if torn is None:
+            return
+
+        await send_stock_report(torn)
+
+
+class TornTrainWatcher(_DailyTornWatcher):
+    target_time = time(7, 0)
+
+    @classmethod
+    async def job(cls, context: ContextTypes.DEFAULT_TYPE) -> None:
+        torn = cls._get_torn(context)
+        if torn is None:
+            return
+
+        await send_train_status(torn)

--- a/main.py
+++ b/main.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python3
 
-import asyncio
 import glob
 import importlib
 import json
@@ -80,10 +79,6 @@ if __name__ == '__main__':
     t = Torn(application.bot, API_KEY , chat_id)
 
     application.bot_data[BotData.TORN] = t
-
-    loop = asyncio.get_event_loop()
-
-    asyncio.run_coroutine_threadsafe(t.run(), loop)
 
     application.bot_data[BotData.TIMETABLE] = TimeTable(pytz.timezone('CET'))
 

--- a/modules/torn_tasks.py
+++ b/modules/torn_tasks.py
@@ -1,0 +1,271 @@
+import asyncio
+import logging
+import time
+from typing import Any, Dict, List
+
+import telegram
+import telegramify_markdown
+
+from modules.database import ValkeyDB
+from modules.torn import Torn, logg_error
+
+
+@logg_error
+async def send_stock_report(torn: Torn) -> None:
+    if torn.company is None:
+        await torn.update_company()
+
+    if not torn.company:
+        logging.error("Company data is unavailable for stock report")
+        return
+
+    company_stock = torn.company.get("company_stock", {})
+    detailed = torn.company.get("company_detailed", {})
+    upgrades = detailed.get("upgrades", {})
+
+    storage_space = upgrades.get("storage_space")
+    if storage_space is None:
+        logging.error("Storage space information missing from company data")
+        return
+
+    try:
+        total_sold = sum(float(v.get("sold_amount", 0)) for v in company_stock.values())
+        total_in_stock = sum(float(v.get("in_stock", 0)) + float(v.get("on_order", 0)) for v in company_stock.values())
+    except (TypeError, ValueError) as exc:
+        logging.error(f"Failed to aggregate company stock data: {exc}")
+        return
+
+    if total_sold == 0:
+        logging.info("No products sold, skipping stock report")
+        return
+
+    aim_ratio = storage_space / total_sold
+    capacity = storage_space - total_in_stock
+    run_out = False
+
+    message = "*Stock Alert*:\n"
+    message += f"Capacity to fill: {capacity}\n"
+    message += f"Global ratio: {aim_ratio:.2f}\n"
+
+    for key, value in company_stock.items():
+        sold = float(value.get("sold_amount", 0))
+        if sold <= 0:
+            continue
+
+        in_stock = float(value.get("in_stock", 0)) + float(value.get("on_order", 0))
+        diff = aim_ratio - (in_stock / sold)
+
+        if diff <= 0.0:
+            logging.debug(f"{key}: no purchase required ({in_stock / sold:.2f})")
+            continue
+
+        buy = diff * sold
+        capacity -= buy
+
+        if run_out:
+            buy = 0.0
+        elif capacity <= 0.0:
+            run_out = True
+            buy = capacity + buy
+
+        message += f"{key}: {buy:.0f} ({in_stock / sold:.2f})\n"
+
+    message += f"Capacity: {round(capacity, 2)}"
+
+    await torn.send(message)
+
+
+@logg_error
+async def send_train_status(torn: Torn) -> None:
+    if torn.company is None:
+        await torn.update_company()
+
+    company = torn.company or {}
+    detailed = company.get("company_detailed", {})
+    trains_available = detailed.get("trains_available", 0)
+
+    if trains_available == 0:
+        logging.info("No trains available")
+        await torn.send("You have no trains available, you can't train anyone")
+        return
+
+    employees = company.get("company_employees", {})
+    if not employees:
+        logging.info("No employees in company data")
+        await torn.send("No employees found to train")
+        return
+
+    order: List[str] = ValkeyDB().get_serialized("last_employee_trained", [])
+
+    current_employee_ids = list(employees.keys())
+    for employee_id, data in employees.items():
+        wage = data.get("wage", 0)
+        if wage > 0 and employee_id not in order:
+            order.append(employee_id)
+        if wage == 0 and employee_id in order:
+            order.remove(employee_id)
+
+    order = [employee_id for employee_id in order if employee_id in current_employee_ids]
+
+    if not order:
+        order = current_employee_ids.copy()
+
+    if not order:
+        await torn.send("No valid employees available for training")
+        return
+
+    order.append(order.pop(0))
+    ValkeyDB().set_serialized("last_employee_trained", order)
+
+    next_employee = employees[order[0]]
+    wage = next_employee.get("wage", 0)
+    preference = ValkeyDB().get_serialized("company_employees", {}).get(order[0], None)
+
+    message = (
+        f"You have *{trains_available} trains* available and your next employee to train is *{next_employee.get('name')}* "
+        f"you can update their wage to `{wage - trains_available}` when you finish. "
+        f"[Quick link](https://www.torn.com/companies.php?step=your&type=1)"
+    )
+
+    if preference is not None:
+        message += f"\n\nPrefers: *{preference}*"
+
+    logging.info(
+        f"Trains available: {trains_available}, next employee: {next_employee.get('name')}"
+    )
+
+    await torn.send(message)
+
+
+async def get_valid_bounties(torn: Torn, min_money: int) -> List[Dict[str, Any]]:
+    await torn.update_bounties()
+
+    if torn.bounties is None:
+        logging.error("Failed to retrieve bounty data")
+        return []
+
+    if torn.user is None:
+        await torn.update_user()
+
+    if torn.user is None:
+        logging.error("User data unavailable, cannot evaluate bounties")
+        return []
+
+    monitor: List[Dict[str, Any]] = []
+    seen_ids: List[int] = []
+
+    my_bts = torn.user.get("total", 0)
+    bounties = torn.bounties.get("bounties", [])
+
+    for bounty in bounties:
+        if bounty.get("reward", 0) < min_money:
+            continue
+
+        target_id = bounty.get("target_id")
+        if target_id in seen_ids:
+            continue
+
+        seen_ids.append(target_id)
+
+        bts = await torn.get_bts(target_id)
+        if not bts or bts.get("TBS") is None:
+            continue
+
+        if my_bts and bts.get("TBS") > my_bts * 1.1:
+            continue
+
+        user_info = await torn.get_basic_user(target_id)
+        if not user_info:
+            continue
+
+        basicicons = user_info.get("basicicons", {})
+        if basicicons.get("icon71") is not None or basicicons.get("icon72") is not None:
+            continue
+
+        user_info["reward"] = bounty.get("reward")
+        user_info["TBS"] = bts.get("TBS")
+        user_info["valid_until"] = bounty.get("valid_until")
+
+        monitor.append(user_info)
+
+    return monitor
+
+
+async def bounty_monitor(torn: Torn) -> None:
+    if torn.user is None:
+        await torn.update_user()
+
+    if torn.user is None:
+        logging.error("Unable to start bounty monitor without user data")
+        return
+
+    my_bts = torn.user.get("total", 0)
+    chat_message: telegram.Message = await torn.send("Starting Bounty monitor")
+
+    while True:
+        monitor = await get_valid_bounties(torn, 500000)
+
+        monitor.sort(key=lambda x: x.get("states", {}).get("hospital_timestamp", 0))
+
+        energy = torn.user.get("energy", {}).get("current", 0)
+        message = f"*Bounty Monitor ({energy}e)*\n\n"
+
+        for user in monitor:
+            reward = "${:,.0f}".format(user.get("reward", 0))
+            tbs = user.get("TBS", 0)
+            bts_percentage = 0 if my_bts == 0 else round(tbs / my_bts * 100)
+
+            message += (
+                f"[{user.get('name')}](https://www.torn.com/loader.php?sid=attack&user2ID={user.get('player_id')}) - {reward} "
+                f"{user.get('status', {}).get('description')} ({bts_percentage}%)\n"
+            )
+
+        message += "\n\nupdated: " + time.strftime('%H:%M:%S', time.localtime())
+
+        await chat_message.edit_text(
+            telegramify_markdown.markdownify(message),
+            parse_mode="MarkdownV2"
+        )
+
+        await asyncio.sleep(60)
+
+
+async def watch_player_bounty(torn: Torn, player_info: Dict[str, Any], limit: int = 60) -> None:
+    now = time.time()
+    hospital = player_info.get("states", {}).get("hospital_timestamp", now)
+
+    wait_time = hospital - now - limit
+    if wait_time > 0:
+        await asyncio.sleep(wait_time)
+
+    user_info = await torn.get_basic_user(player_info.get("player_id"))
+    if not user_info:
+        return
+
+    basicicons = user_info.get("basicicons", {})
+    if basicicons.get("icon13") is None:
+        return
+
+    new_hospital = user_info.get("states", {}).get("hospital_timestamp")
+    if new_hospital and new_hospital != hospital:
+        player_info["states"] = user_info.get("states", {})
+        await watch_player_bounty(torn, player_info, limit=limit)
+        return
+
+    reward = "${:,.0f}".format(player_info.get("reward", 0))
+    try:
+        message = await torn.send(
+            f"{user_info.get('name')} is about to leave hospital with a bounty of {reward}. "
+            f"[Attack](https://www.torn.com/loader.php?sid=attack&user2ID={player_info.get('player_id')})",
+            clean=False
+        )
+    except Exception as exc:
+        logging.error(f"Failed to send bounty notification: {exc}")
+        return
+
+    await asyncio.sleep(max(limit, 0))
+
+    try:
+        await message.delete()
+    except Exception as exc:
+        logging.error(f"Failed to delete bounty notification: {exc}")


### PR DESCRIPTION
## Summary
- move Torn company, stock, and train routines into dedicated job queue watchers that fire at the desired daily times
- extract bounty monitoring logic into reusable helpers and watcher classes and update commands to call the shared helpers
- simplify the Torn service class and API key command now that scheduling is handled by watchers

## Testing
- python -m compileall bot/watchers/torn_company.py bot/watchers/torn_bounty.py modules/torn_tasks.py modules/torn.py bot/commands/torn/*.py main.py
- python -m compileall modules/torn.py


------
https://chatgpt.com/codex/tasks/task_e_68f50fd85f4c832d89886a969af5c752