### PR TITLE
Add isolated shell workspace tools for main agent

### DIFF
--- a/enums/bot_data.py
+++ b/enums/bot_data.py
@@ -17,6 +17,8 @@ class BotData(Enum):
 
     FILE_MANAGER = "file_manager"
 
+    SHELL = "shell_environment"
+
 
     LOCATION = "location"
 

--- a/main.py
+++ b/main.py
@@ -14,9 +14,9 @@ from bot.classes.CustomeAplicationBuilder import CustomApplicationBuilder
 from enums.database import DatabaseConstants
 from modules.calendar import Calendar
 from modules.database import ValkeyDB
-from modules.file_system import InMemoryFileSystem
 from modules.location_manager import LocationManager
 from modules.memory import Memory
+from modules.shell import EphemeralShell
 from modules.timetable import TimeTable
 from modules.tools import init_file_manager
 from modules.torn import Torn
@@ -70,6 +70,7 @@ if __name__ == '__main__':
     application.bot_data[BotData.LOCATION] = LocationManager(history_size=7)
 
     application.bot_data[BotData.FILE_MANAGER] = ValkeyDB().get_serialized(DatabaseConstants.FILE_MANAGER, init_file_manager())
+    application.bot_data[BotData.SHELL] = EphemeralShell()
 
 
     chat_id = ValkeyDB().get_serialized(DatabaseConstants.MAIN_CHAT_ID, None)

--- a/modules/shell.py
+++ b/modules/shell.py
@@ -1,0 +1,188 @@
+"""Ephemeral shell execution utilities for the assistant."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+
+@dataclass
+class ShellResult:
+    """Structured output returned after a shell command finishes."""
+
+    command: str
+    exit_code: Optional[int]
+    stdout: str
+    stderr: str
+    timed_out: bool
+    cwd: str
+
+    def as_dict(self) -> Dict[str, object]:
+        """Return a JSON-serialisable representation of the result."""
+        return {
+            "command": self.command,
+            "exit_code": self.exit_code,
+            "stdout": self.stdout,
+            "stderr": self.stderr,
+            "timed_out": self.timed_out,
+            "cwd": self.cwd,
+        }
+
+
+class EphemeralShell:
+    """Execute commands inside an isolated, temporary workspace.
+
+    The workspace lives in a temporary directory that is discarded whenever the
+    process restarts or when :meth:`reset` is called.  Commands run without an
+    interactive shell which prevents features such as redirection or chaining
+    through ``;``.  Only the command itself is executed which keeps execution
+    deterministic and limits the risk of shell injection.
+    """
+
+    def __init__(self, *, max_timeout: int = 30, max_command_length: int = 1024):
+        self._workspace = tempfile.mkdtemp(prefix="assistant-shell-")
+        self._max_timeout = max(1, max_timeout)
+        self._max_command_length = max_command_length
+        self._base_env = {
+            "PATH": os.environ.get("PATH", ""),
+            "LANG": os.environ.get("LANG", "C.UTF-8"),
+        }
+        self._refresh_env()
+
+    def _refresh_env(self) -> None:
+        """Update HOME/PWD in the sandboxed environment."""
+        self._base_env["HOME"] = self._workspace
+        self._base_env["PWD"] = self._workspace
+
+    @property
+    def workspace(self) -> str:
+        """Return the current workspace path."""
+        return self._workspace
+
+    def run(self, command: str, timeout_seconds: Optional[int] = None) -> Dict[str, object]:
+        """Execute *command* inside the ephemeral workspace.
+
+        Args:
+            command: Command to execute.  The command is tokenised using
+                :func:`shlex.split` and therefore must not rely on shell
+                features such as redirection.
+            timeout_seconds: Optional timeout for the command.  Values above the
+                configured maximum are clipped.
+        """
+
+        cleaned_command = command.strip()
+        if not cleaned_command:
+            return ShellResult(
+                command="",
+                exit_code=None,
+                stdout="",
+                stderr="No command provided.",
+                timed_out=False,
+                cwd=self.workspace,
+            ).as_dict()
+
+        if len(cleaned_command) > self._max_command_length:
+            return ShellResult(
+                command=cleaned_command,
+                exit_code=None,
+                stdout="",
+                stderr="Command too long.",
+                timed_out=False,
+                cwd=self.workspace,
+            ).as_dict()
+
+        try:
+            args = shlex.split(cleaned_command)
+        except ValueError as exc:  # Raised when quotes are not balanced.
+            return ShellResult(
+                command=cleaned_command,
+                exit_code=None,
+                stdout="",
+                stderr=f"Failed to parse command: {exc}",
+                timed_out=False,
+                cwd=self.workspace,
+            ).as_dict()
+
+        if not args:
+            return ShellResult(
+                command=cleaned_command,
+                exit_code=None,
+                stdout="",
+                stderr="No executable specified.",
+                timed_out=False,
+                cwd=self.workspace,
+            ).as_dict()
+
+        timeout = timeout_seconds or self._max_timeout
+        timeout = min(max(1, timeout), self._max_timeout)
+
+        try:
+            completed = subprocess.run(
+                args,
+                cwd=self.workspace,
+                timeout=timeout,
+                capture_output=True,
+                text=True,
+                env=self._base_env,
+            )
+            result = ShellResult(
+                command=cleaned_command,
+                exit_code=completed.returncode,
+                stdout=completed.stdout,
+                stderr=completed.stderr,
+                timed_out=False,
+                cwd=self.workspace,
+            )
+        except FileNotFoundError:
+            result = ShellResult(
+                command=cleaned_command,
+                exit_code=None,
+                stdout="",
+                stderr=f"Executable not found: {args[0]}",
+                timed_out=False,
+                cwd=self.workspace,
+            )
+        except subprocess.TimeoutExpired as exc:
+            result = ShellResult(
+                command=cleaned_command,
+                exit_code=None,
+                stdout=exc.stdout or "",
+                stderr=exc.stderr or "",
+                timed_out=True,
+                cwd=self.workspace,
+            )
+
+        return result.as_dict()
+
+    def list_workspace(self) -> Dict[str, object]:
+        """Return a snapshot of files present in the workspace."""
+        contents = []
+        for root, dirs, files in os.walk(self.workspace):
+            relative_root = os.path.relpath(root, self.workspace)
+            if relative_root == ".":
+                relative_root = ""
+            for directory in sorted(dirs):
+                path = os.path.join(relative_root, directory).strip("/")
+                contents.append({"type": "directory", "path": path or "."})
+            for file_name in sorted(files):
+                path = os.path.join(relative_root, file_name).strip("/")
+                contents.append({"type": "file", "path": path or file_name})
+        return {"workspace": self.workspace, "contents": contents}
+
+    def reset(self) -> Dict[str, object]:
+        """Reset the workspace by creating a fresh temporary directory."""
+        shutil.rmtree(self.workspace, ignore_errors=True)
+        self._workspace = tempfile.mkdtemp(prefix="assistant-shell-")
+        self._refresh_env()
+        return {"status": "reset", "workspace": self.workspace}
+
+    def __del__(self) -> None:  # pragma: no cover - defensive cleanup
+        try:
+            shutil.rmtree(self.workspace, ignore_errors=True)
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary
- add an EphemeralShell utility that runs commands inside a temporary sandbox and reports structured results
- register shell workspace management tools on the main agent and expose the sandbox through bot data
- ensure the application initialises the shell workspace so commands remain ephemeral between resets

## Testing
- python -m compileall agents modules enums main.py

------
https://chatgpt.com/codex/tasks/task_e_68f525444d50832d87ac2a57b1cf846e